### PR TITLE
fix: enabled buttons fix

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,7 +23,8 @@
     <p class="subtitle">
         Rectangular
         <span>With Labels</span>
-        <span>Brand Colour</span>
+        <span>Brand Colours</span>
+        <span>All Buttons</span>
     </p>
     <div class="container">
         {{ .Scratch.Set "withLabel" true }}
@@ -32,7 +33,8 @@
     <p class="subtitle">
         Square
         <span>Labelless</span>
-        <span>Brand Colour</span>
+        <span>Brand Colours</span>
+        <span>All Buttons</span>
     </p>
     <div class="container">
         {{ .Scratch.Set "withLabel" false }}
@@ -41,7 +43,8 @@
     <p class="subtitle">
         Round
         <span>Labelless</span>
-        <span>Brand Colour</span>
+        <span>Brand Colours</span>
+        <span>All Buttons</span>
     </p>
     <div class="container">
         {{ .Scratch.Set "round" true }}
@@ -51,6 +54,7 @@
         Rectangular
         <span>With Labels</span>
         <span>Matching Colour</span>
+        <span>All Buttons</span>
     </p>
     <div class="container">
         {{ .Scratch.Set "withLabel" true }}
@@ -64,6 +68,7 @@
         Square
         <span>Labelless</span>
         <span>Matching Colour</span>
+        <span>All Buttons</span>
     </p>
     <div class="container">
         {{ .Scratch.Set "withLabel" false }}
@@ -74,9 +79,22 @@
         Round
         <span>Labelless</span>
         <span>Matching Colour</span>
+        <span>All Buttons</span>
     </p>
     <div class="container">
         {{ .Scratch.Set "round" true }}
+        {{ partial "utils/share-buttons/index.html" . }}
+    </div>
+    <p class="subtitle">
+        Rectangular
+        <span>Select Buttons</span>
+        <span>With Labels</span>
+        <span>Brand Colours</span>
+    </p>
+    <div class="container">
+        {{ partial "utils/share-buttons/helpers/reset.html" . }}
+        {{ .Scratch.Set "withLabel" true }}
+        {{ .Scratch.Set "enabled" (slice "email" "twitter" "linkedin" "facebook" "reddit" "whatsapp" "pinterest") }}
         {{ partial "utils/share-buttons/index.html" . }}
     </div>
 {{ end }}

--- a/layouts/partials/utils/share-buttons/helpers/reset.html
+++ b/layouts/partials/utils/share-buttons/helpers/reset.html
@@ -1,0 +1,5 @@
+{{ .Scratch.Delete "withLabel" }}
+{{ .Scratch.Delete "round" }}
+{{ .Scratch.Delete "color" }}
+{{ .Scratch.Delete "activeBackground" }}
+{{ .Scratch.Delete "activeColor" }}

--- a/layouts/partials/utils/share-buttons/index.html
+++ b/layouts/partials/utils/share-buttons/index.html
@@ -1,7 +1,8 @@
 <div class="share-buttons">    
     {{ $all := false }}
-    
-    {{ if eq ( .Param "enabled" ) nil }}
+    {{ $enabled := or (.Scratch.Get "enabled") slice }}
+
+    {{ if eq (len $enabled) 0 }}
     {{ $all = true }}
     {{ end }}
 
@@ -9,7 +10,7 @@
     
     {{ $context := . }}
     {{ range $smb := $smButtons }}
-        {{ if or $all ( in .enabled $smb ) }}
+        {{ if or $all ( in $enabled $smb ) }}
             {{ partial (printf "utils/share-buttons/%s.html" $smb ) $context }}
         {{ end }}
     {{ end }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
I'm unable to enable select buttons. 

This happens because the `enabled` property is checked for in the page parameters instead of the page scratch pad. 

Here:
https://github.com/koc-he/share/blob/344f1a7691e13e43831234cf4e46f51e90fc7f86/layouts/partials/utils/share-buttons/index.html#L4

and here:
https://github.com/koc-he/share/blob/344f1a7691e13e43831234cf4e46f51e90fc7f86/layouts/partials/utils/share-buttons/index.html#L12

**Issue Number:** #20 


## What is the new behavior?
Only buttons with their tags in the `enabled` slice now appear.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- I also added a partial to reset the scratch pad by deleting only the values used by this module. 
- I added examples for `enabled` buttons to the demo page. 
- I added labels to the examples to show the difference between select buttons and all buttons. 

